### PR TITLE
update repo location

### DIFF
--- a/docs/technology/quick-installation.mdx
+++ b/docs/technology/quick-installation.mdx
@@ -30,8 +30,10 @@ sudo apt-get update
 sudo apt-get install -y wget gnupg
 
 # Add the Pyrsia keys to verify packages
-wget -qO - https://pyrsia.io/public.key | sudo apt-key add -
-echo "deb https://pyrsia.io/repo focal main" | sudo tee -a /etc/apt/sources.list > /dev/null
+wget -q -O - https://repo.pyrsia.io/repos/Release.key |  gpg --dearmor  > pyrsia.gpg
+sudo install -o root -g root -m 644 pyrsia.gpg /etc/apt/trusted.gpg.d/
+rm pyrsia.gpg
+echo "deb https://repo.pyrsia.io/repos/nightly focal main" | sudo tee -a /etc/apt/sources.list > /dev/null
 sudo apt-get update
 
 # Install


### PR DESCRIPTION
Associated to PR #35 which is on the gh-pages branch.  This PR updates the doc to reflect the new install.sh commands.

https://github.com/pyrsia/pyrsia#install-pyrsia-and-joining-the-network
- This section refers to the location of  install.sh which is not changing

https://pyrsia.io/docs/technology/quick-installation/#using-the-web-script
- This section has been updated to be in  sync with install.sh