### PR TITLE
fix broken link on rfc template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10358,9 +10358,9 @@
       }
     },
     "node_modules/jsdom/node_modules/ws": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10833,9 +10833,9 @@
       }
     },
     "node_modules/mathjax-full": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.1.tgz",
-      "integrity": "sha512-aUz9o16MGZdeiIBwZjAfUBTiJb7LRqzZEl1YOZ8zQMGYIyh1/nxRebxKxjDe9L+xcZCr2OHdzoFBMcd6VnLv9Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
       "dependencies": {
         "esm": "^3.2.25",
         "mhchemparser": "^4.1.0",
@@ -25503,9 +25503,9 @@
           }
         },
         "ws": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-          "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+          "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
           "requires": {}
         }
       }
@@ -25859,9 +25859,9 @@
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
     },
     "mathjax-full": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.1.tgz",
-      "integrity": "sha512-aUz9o16MGZdeiIBwZjAfUBTiJb7LRqzZEl1YOZ8zQMGYIyh1/nxRebxKxjDe9L+xcZCr2OHdzoFBMcd6VnLv9Q==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
       "requires": {
         "esm": "^3.2.25",
         "mhchemparser": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "download-main-repo": "wget -c https://github.com/pyrsia/pyrsia/archive/refs/heads/main.tar.gz -O - | tar -xz -C /tmp && node .github/actions/custom-edit-url.js /tmp/pyrsia-main pyrsia/pyrsia && cp -r /tmp/pyrsia-main/docs ./ && cp -r /tmp/pyrsia-main/blog ./",
+    "download-main-repo": "wget -c https://github.com/pyrsia/pyrsia/archive/refs/heads/main.tar.gz -O - | tar -xz -C /tmp && node .github/actions/custom-edit-url.js /tmp/pyrsia-main pyrsia/pyrsia && cp -r /tmp/pyrsia-main/docs ./ && cp -r /tmp/pyrsia-main/blog ./ && find . -name 0000-template.md -exec rm {} \\;",
     "download-community-repo": "wget -c https://github.com/pyrsia/.github/archive/refs/heads/main.tar.gz -O - | tar -xz -C /tmp && node .github/actions/custom-edit-url.js /tmp/.github-main pyrsia/.github && cp /tmp/.github-main/*.md ./docs/get_involved",
     "download-repos": "npm run download-main-repo && npm run download-community-repo",
     "docusaurus": "docusaurus",


### PR DESCRIPTION
Need to exclude the rfc template file from being copied over to the website.  It is only used for reference by the developer when creating a new rfc.  Excluding it fixes a broken link on the site.