### PR TITLE
Fixes configuration so that the blog folder is not copied over

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "download-main-repo": "wget -c https://github.com/pyrsia/pyrsia/archive/refs/heads/main.tar.gz -O - | tar -xz -C /tmp && node .github/actions/custom-edit-url.js /tmp/pyrsia-main pyrsia/pyrsia && cp -r /tmp/pyrsia-main/docs ./ && cp -r /tmp/pyrsia-main/blog ./ && find . -name 0000-template.md -exec rm {} \\;",
+    "download-main-repo": "wget -c https://github.com/pyrsia/pyrsia/archive/refs/heads/main.tar.gz -O - | tar -xz -C /tmp && node .github/actions/custom-edit-url.js /tmp/pyrsia-main pyrsia/pyrsia && cp -r /tmp/pyrsia-main/docs ./ && find . -name 0000-template.md -exec rm {} \\;",
     "download-community-repo": "wget -c https://github.com/pyrsia/.github/archive/refs/heads/main.tar.gz -O - | tar -xz -C /tmp && node .github/actions/custom-edit-url.js /tmp/.github-main pyrsia/.github",
     "download-repos": "npm run download-main-repo && npm run download-community-repo",
     "docusaurus": "docusaurus",


### PR DESCRIPTION
- previously the blogs were being copied from the pyrsia repo
- we want to move the blogs to this repo because they are not in sync with the codebase usually and adding all collateral for blogs makes the main repo too noisy