### PR TITLE
Add semicolons, cleanup custom_edit_url and clean old files

### DIFF
--- a/.github/actions/custom-edit-url.js
+++ b/.github/actions/custom-edit-url.js
@@ -57,9 +57,8 @@ const branch = argv[4] || 'main'
 
 const result = getAllFiles(dir).filter((value) => value.endsWith('.md') || value.endsWith('.mdx'))
 for (const file of result) {
-    const value = file.substring((dir + '/').length)
-    console.log(value)
+    const value = file.substring((dir + '/').length);
     addFrontMatter(file,
         `custom_edit_url: https://github.com/${repo}/blob/${branch}/${value}`
-    )
+    );
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
-          keep_files: true
+          keep_files: false
           cname: pyrsia.io
           user_name: github-actions[bot]
           user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/blog/2022-01-28-blockchain-consensus.md
+++ b/blog/2022-01-28-blockchain-consensus.md
@@ -1,5 +1,4 @@
 ---
-custom_edit_url: https://github.com/pyrsia/pyrsia/edit/main/blog/2022-01-28-blockchain-consensus.md
 title: Blockchain Consensus
 authors:
 - name: Christopher McArthur

--- a/blog/2022-06-03-peer-metrics.md
+++ b/blog/2022-06-03-peer-metrics.md
@@ -1,5 +1,4 @@
 ---
-custom_edit_url: https://github.com/pyrsia/pyrsia/edit/main/blog/2022-06-03-peer-metrics.md
 title:  Peer Metrics in the Pyrsia Network
 authors:
 - name: Mark Seaborn


### PR DESCRIPTION
Added semicolons based on previous PR comments.  Cleaned up hardcoded custom_edit_url since they are generated by the nodejs script.  Changed the keep_files to false in order to remove old files due to refactoring.  The old files were causing 404s.