### PR TITLE
add missing install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+apt-get update
+apt-get install -y wget gnupg
+wget -q -O - https://repo.pyrsia.io/repos/Release.key |  gpg --dearmor  > pyrsia.gpg
+install -o root -g root -m 644 pyrsia.gpg /etc/apt/trusted.gpg.d/
+rm pyrsia.gpg
+echo "deb https://repo.pyrsia.io/repos/nightly focal main" >> /etc/apt/sources.list
+apt-get update
+apt-get install -y pyrsia


### PR DESCRIPTION
Setting the keep_files: false in the deployment workflow caused the install.sh to be delete from the gh-pages branch.  Moving the install.sh to the main branch which is then copied over as part of the deployment workflow.