### PR TITLE
Added copy of install.sh into build directory for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
       - run: |
           npm ci
           npm run build
+          cp install.sh build
       - if: github.event_name != 'pull_request'
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+apt-get update
+apt-get install -y wget gnupg
+wget -q -O - https://repo.pyrsia.io/repos/Release.key |  gpg --dearmor  > pyrsia.gpg
+install -o root -g root -m 644 pyrsia.gpg /etc/apt/trusted.gpg.d/
+rm pyrsia.gpg
+echo "deb https://repo.pyrsia.io/repos/nightly focal main" >> /etc/apt/sources.list
+apt-get update
+apt-get install -y pyrsia


### PR DESCRIPTION
The install.sh was not consistently getting added to the gh-pages.  Adding the cp ensured that the install.sh copied into the build directory and pushed into the gh-pages.